### PR TITLE
ENG-1657 - Update max-repo to support variable email-template location

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -57,7 +57,8 @@ run() {
   fi
 
   if [ ! -z "${npm_package_config_max_email_templates}" ]; then
-    checkout_repo "email-templates" "${npm_package_config_max_email_templates}" "email-templates"
+    local email_templates_checkout_path="${npm_package_config_max_email_templates_path:-email-templates}"
+    checkout_repo "email-templates" "${npm_package_config_max_email_templates}" "${email_templates_checkout_path}"
   fi
 
   if [ ! -z "${npm_package_config_max_melodies_source}" ]; then


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make the email-templates repo checkout path configurable in cli.sh with a default of `email-templates`.
> 
> - **CLI (`cli.sh`)**:
>   - Make `email-templates` checkout path configurable via `npm_package_config_max_email_templates_path`, defaulting to `email-templates`.
>   - Use `email_templates_checkout_path` when calling `checkout_repo` for `email-templates`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09008d033bafc354037b635b890d1fe34900f244. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->